### PR TITLE
WIP-support 10 update dev tooling

### DIFF
--- a/src/NServiceBus.Heartbeat.AcceptanceTests/NServiceBus.Heartbeat.AcceptanceTests.csproj
+++ b/src/NServiceBus.Heartbeat.AcceptanceTests/NServiceBus.Heartbeat.AcceptanceTests.csproj
@@ -13,9 +13,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
-    <PackageReference Include="NUnit" Version="3.7.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.8.0-alpha1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="NUnit" Version="3.11.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.11.2" />
   </ItemGroup>
 
 </Project>

--- a/src/NServiceBus.Heartbeat.Tests/NServiceBus.Heartbeat.Tests.csproj
+++ b/src/NServiceBus.Heartbeat.Tests/NServiceBus.Heartbeat.Tests.csproj
@@ -15,9 +15,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
-    <PackageReference Include="NUnit" Version="3.7.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.8.0-alpha1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="NUnit" Version="3.11.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.11.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NServiceBus.Heartbeat/NServiceBus.Heartbeat.csproj
+++ b/src/NServiceBus.Heartbeat/NServiceBus.Heartbeat.csproj
@@ -16,13 +16,8 @@
 
   <ItemGroup>
     <PackageReference Include="Particular.CodeRules" Version="0.2.0" PrivateAssets="All" />
-    <PackageReference Include="Particular.Packaging" Version="0.1.0" PrivateAssets="All" />
+    <PackageReference Include="Particular.Packaging" Version="0.2.1" PrivateAssets="All" />
     <PackageReference Include="GitVersionTask" Version="4.0.0-beta0012" PrivateAssets="All" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="SourceLink.Create.GitHub" Version="2.5.0" PrivateAssets="All" />
-    <DotNetCliToolReference Include="dotnet-sourcelink-git" Version="2.5.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This updates development tooling on the `support-1.0` branch.
Note: This should not be squashed.