### PR TITLE
Upate to latest Core package

### DIFF
--- a/src/NServiceBus.Heartbeat.AcceptanceTests/InMemoryTransport.cs
+++ b/src/NServiceBus.Heartbeat.AcceptanceTests/InMemoryTransport.cs
@@ -1,5 +1,6 @@
 ﻿namespace NServiceBus.Heartbeat.AcceptanceTests
 {
+    using System;
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
@@ -31,6 +32,9 @@
             }
 
             public override Task Shutdown(CancellationToken cancellationToken = default) => Task.CompletedTask;
+#pragma warning disable CS0618
+            public override string ToTransportAddress(QueueAddress address) => transport.ToTransportAddress(address);
+#pragma warning restore CS0618
         }
 
         public InMemoryTransport() : base(TransportTransactionMode.None, true, true, true)
@@ -49,6 +53,7 @@
             return infrastructure;
         }
 
+        [Obsolete("Inject the ITransportAddressResolver type to access the address translation mechanism at runtime. See the NServiceBus version 8 upgrade guide for further details. Will be treated as an error from version 9.0.0. Will be removed in version 10.0.0.", false)]
         public override string ToTransportAddress(QueueAddress address) => address.BaseAddress;
 
         public override IReadOnlyCollection<TransportTransactionMode> GetSupportedTransactionModes() =>

--- a/src/NServiceBus.Heartbeat.AcceptanceTests/NServiceBus.Heartbeat.AcceptanceTests.csproj
+++ b/src/NServiceBus.Heartbeat.AcceptanceTests/NServiceBus.Heartbeat.AcceptanceTests.csproj
@@ -10,7 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NServiceBus.AcceptanceTesting" Version="8.0.0-alpha.1897" />
+    <PackageReference Include="NServiceBus.AcceptanceTesting" Version="8.0.0-alpha.1900" />
     <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="3.0.0-alpha.155" />
   </ItemGroup>
 

--- a/src/NServiceBus.Heartbeat.Tests/NServiceBus.Heartbeat.Tests.csproj
+++ b/src/NServiceBus.Heartbeat.Tests/NServiceBus.Heartbeat.Tests.csproj
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="GitHubActionsTestLogger" Version="1.2.0" />
-    <PackageReference Include="NServiceBus" Version="8.0.0-alpha.1897" />
+    <PackageReference Include="NServiceBus" Version="8.0.0-alpha.1900" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NServiceBus.Heartbeat/NServiceBus.Heartbeat.csproj
+++ b/src/NServiceBus.Heartbeat/NServiceBus.Heartbeat.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NServiceBus" Version="[8.0.0-alpha.1897, 9.0.0)" />
+    <PackageReference Include="NServiceBus" Version="[8.0.0-alpha.1900, 9.0.0)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NServiceBus.Heartbeat/ServiceControlBackend.cs
+++ b/src/NServiceBus.Heartbeat/ServiceControlBackend.cs
@@ -12,10 +12,10 @@
 
     class ServiceControlBackend
     {
-        public ServiceControlBackend(string destinationQueue, string localAddress)
+        public ServiceControlBackend(string destinationQueue, ReceiveAddresses receiveAddresses)
         {
             this.destinationQueue = destinationQueue;
-            this.localAddress = localAddress;
+            this.receiveAddresses = receiveAddresses;
         }
 
         public Task Send(object messageToSend, TimeSpan timeToBeReceived, IMessageDispatcher dispatcher, CancellationToken cancellationToken = default)
@@ -38,9 +38,9 @@
                 [Headers.MessageIntent] = sendIntent
             };
 
-            if (localAddress != null)
+            if (receiveAddresses != null)
             {
-                headers[Headers.ReplyToAddress] = localAddress;
+                headers[Headers.ReplyToAddress] = receiveAddresses.MainReceiveAddress;
             }
 
             var outgoingMessage = new OutgoingMessage(Guid.NewGuid().ToString(), headers, body);
@@ -51,7 +51,7 @@
 
         readonly string sendIntent = MessageIntent.Send.ToString();
         string destinationQueue;
-        string localAddress;
+        readonly ReceiveAddresses receiveAddresses; // note that ReceiveAddresses will be null on send-only endpoints
 
         static IJsonSerializerStrategy serializerStrategy = new MessageSerializationStrategy();
     }


### PR DESCRIPTION
The `ServiceControlBackend` class does optionally add the reply address to the data, so it needs to receive that in a send-only compatible way from `ReceiveAddresses` which isn't registered in send-only endpoints.